### PR TITLE
Add session recap section to Acroterra campaign page

### DIFF
--- a/src/content/recaps/acroterra-2025-04-28.md
+++ b/src/content/recaps/acroterra-2025-04-28.md
@@ -1,6 +1,6 @@
 ---
 campaignId: acroterra
-date: "2025-08-11"
+date: "2025-04-28"
 title: "Entry I: Whispers, Weapons, and the Crimson Brand"
 ---
 

--- a/src/pages/campaigns/[slug].astro
+++ b/src/pages/campaigns/[slug].astro
@@ -3,6 +3,7 @@ import BaseHead from '../../components/BaseHead.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import { campaigns } from '../../campaigns';
+import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
   return campaigns.map((c) => ({
@@ -14,6 +15,14 @@ export async function getStaticPaths() {
 const { campaign } = Astro.props;
 const isAcroterra = campaign.id === 'acroterra';
 const pdfSrc = '/acroterra.pdf';
+
+// Load session recaps for this campaign
+const recaps = await Promise.all(
+  (await getCollection('recaps'))
+    .filter((r) => r.data.campaignId === campaign.id)
+    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+    .map(async (r) => ({ ...r, Content: (await render(r)).Content }))
+);
 ---
 
 <!doctype html>
@@ -103,6 +112,20 @@ const pdfSrc = '/acroterra.pdf';
             0 12px 28px rgba(0,0,0,.5);
         }
       }
+
+      .recaps {
+        margin-top: 48px;
+      }
+
+      .recap {
+        margin-bottom: 40px;
+      }
+
+      .recap-date {
+        margin-top: 0;
+        font-size: 0.9rem;
+        opacity: 0.8;
+      }
     </style>
   </head>
   <body>
@@ -128,6 +151,25 @@ const pdfSrc = '/acroterra.pdf';
       <section>
         <p>{campaign.blurb}</p>
       </section>
+
+      {recaps.length > 0 && (
+        <section class="recaps">
+          <h2>Session Recaps</h2>
+          {recaps.map((recap) => (
+            <article class="recap" id={recap.id}>
+              <h3>{recap.data.title}</h3>
+              <p class="recap-date">
+                {recap.data.date.toLocaleDateString(undefined, {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </p>
+              <recap.Content />
+            </article>
+          ))}
+        </section>
+      )}
     </main>
     <Footer />
   </body>


### PR DESCRIPTION
## Summary
- Load session recaps from Astro content collection for each campaign
- Render recap entries on campaign pages with dates and content
- Add first Acroterra recap entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68983e552b548329b0179ffbd838e1e1