### PR TITLE
style recap section for better readability

### DIFF
--- a/src/pages/campaigns/[slug].astro
+++ b/src/pages/campaigns/[slug].astro
@@ -119,6 +119,14 @@ const recaps = await Promise.all(
 
       .recap {
         margin-bottom: 40px;
+        padding: 20px;
+        background: rgba(0,0,0,0.5);
+        border-radius: 12px;
+      }
+
+      .recap h3 {
+        color: #fff;
+        margin-top: 0;
       }
 
       .recap-date {


### PR DESCRIPTION
## Summary
- make recap titles white
- wrap recap entries in translucent black rounded box

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6898422797dc8329a202b2afccfe5cfd