### PR TITLE
style: make Session Recaps heading white

### DIFF
--- a/src/pages/campaigns/[slug].astro
+++ b/src/pages/campaigns/[slug].astro
@@ -117,6 +117,10 @@ const recaps = await Promise.all(
         margin-top: 48px;
       }
 
+      .recaps h2 {
+        color: #fff;
+      }
+
       .recap {
         margin-bottom: 40px;
         padding: 20px;


### PR DESCRIPTION
## Summary
- make the "Session Recaps" heading white on campaign page

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689846a726b4832991d24f2045294444