### PR TITLE
Add July 14 2025 Acroterra recap

### DIFF
--- a/src/content/recaps/acroterra-2025-07-14.md
+++ b/src/content/recaps/acroterra-2025-07-14.md
@@ -1,0 +1,16 @@
+---
+campaignId: acroterra
+date: "2025-07-14"
+title: "Entry II: Chains, Blood, and the Sunken Heart"
+---
+
+Previously in Wildvale…
+
+At the Draeven Estate, Lord Aiden Draeven received the party in a cold, fireless hall. He revealed a hidden shame—Gabriel Draeven, an honored elder, had fallen to the Blood Tide and was sealed in the family crypt. The wards were failing, and Aiden needed the matter ended quietly in exchange for access to his most guarded archives.
+
+In the crypt’s dust and darkness, Gabriel—feral but flickering with memory—warned of chains breaking, blood remembering, and a figure waiting in the tide. When the party struck him down, they uncovered a rusted House Valdane sigil, arcane seals like those at the Cathedral Veilstone, and blood-scrawled warnings of a “Sunken Heart beneath the drowned halls.”
+
+Within the Vault of Remnants, they met Selwin Draeven, a needle-fingered archivist who confirmed the second chain lies in the drowned ruins of House Valdane’s Sunken Archives. He offered only a torn, waterlogged map and a warning—what sleeps there was never meant to wake.
+
+Meanwhile, unrest spreads: House Luthair arms their knights, market posters brand Viola a heretic, a gray-robed watcher stalks Medan, and the Blood Tide fog now creeps into noble courts and temple spires. The city’s pulse quickens.
+


### PR DESCRIPTION
## Summary
- add second Acroterra recap for July 14, 2025

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68984c703fcc8329ab4673a54f9f3728