### PR TITLE
Use play.questwithwasem.com for homepage VTT button

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 
-const vttUrl = 'https://foundryvtt.questwithwasem.com';
+const vttUrl = 'https://play.questwithwasem.com';
 ---
 
 <!doctype html>


### PR DESCRIPTION
### Motivation
- Align the homepage CTA with the intended Virtual Tabletop destination by updating the button target URL.

### Description
- Updated the `vttUrl` constant in `src/pages/index.astro` from `https://foundryvtt.questwithwasem.com` to `https://play.questwithwasem.com` so the homepage button opens the correct VTT.

### Testing
- Ran `npm run build` which completed successfully and prerendered the site (including `/index.html`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c734876f508329a26d272ca53e4491)